### PR TITLE
Allows setting an endpoint as well as Flysystem meta options for S3 Adapter

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -88,7 +88,9 @@ class Shopware_Plugins_Frontend_SwagMediaS3_Bootstrap extends Shopware_Component
             'region' => '',
             'version' => 'latest',
             'bucket' => '',
-            'prefix' => ''
+            'prefix' => '',
+            'endpoint' => null,
+            'metaOptions' => []
         ];
 
         $config = array_merge($defaultConfig, $args->get('config'));
@@ -99,9 +101,10 @@ class Shopware_Plugins_Frontend_SwagMediaS3_Bootstrap extends Shopware_Component
                 'secret' => $config['secret'],
             ],
             'region' => $config['region'],
+            'endpoint' => $config['endpoint'],
             'version' => $config['version']
         ]);
 
-        return new AwsS3Adapter($client, $config['bucket'], $config['prefix']);
+        return new AwsS3Adapter($client, $config['bucket'], $config['prefix'], $config['metaOptions']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Update your `config.php` in your root directory and fill in your own values
 | region | Yes | The S3 region, e.g. `eu-central-1` |
 | bucket | Yes | Your S3 bucket name |
 | prefix | No | An optional path prefix for your media files |
+| endpoint | No | Sets the S3 endpoint specifically (e.g. non-AWS S3) |
+| metaOptions | No | Allows setting options per file specific to [Flysystem S3 Adapter](https://github.com/thephpleague/flysystem-aws-s3-v3/blob/4dea5e457d046b43434824e68e64f45a8dc7eeda/src/AwsS3Adapter.php#L31) |
 
 ## License
 


### PR DESCRIPTION
Hey, super happy about the whole abstraction of the media handling. We needed to customise some more settings of the Flysystem S3 Adapter and thus added two configuration options to do so.

Cheers, Lars
