### PR TITLE
updated Readme config for s3 adapter.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,12 @@ Update your ``config.php`` in your root directory and fill in your own values::
           's3' => [
               'type' => 's3',
               'mediaUrl' => 'YOUR_S3_OR_CLOUDFRONT_ENDPOINT',
-              'key' => 'YOUR_AWS_KEY',
-              'secret' => 'YOUR_AWS_SECRET',
               'region' => 'YOUR_S3_REGION',
               'bucket' => 'YOUR_S3_BUCKET_NAME',
-              'prefix' => ''
+              'credentials' => [
+                'key' => 'YOUR_AWS_KEY',
+                'secret' => 'YOUR_AWS_SECRET',
+              ]
           ]
       ]
   ]


### PR DESCRIPTION
Needed this change to resolve this fatal error:
`Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException: The options "key", "prefix", "secret" do not exist. Defined options are: "bucket", "credentials", "mediaUrl", "region", "root", "type", "url", "version". in /home/vagrant/www/shopware/vendor/symfony/options-resolver/OptionsResolver.php:645`